### PR TITLE
Escape parameters with quote method from connection driver

### DIFF
--- a/src/Psr3Logger.php
+++ b/src/Psr3Logger.php
@@ -16,30 +16,38 @@
 namespace Tuupola\DBAL\Logging;
 
 use Doctrine\DBAL\Logging\SQLLogger;
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\SQLParserUtils;
 
 class Psr3Logger implements SQLLogger
 {
     public $logger;
+    public $connection;
     public $sql = "";
     public $start = null;
 
-    public function __construct($logger = null)
+    public function __construct($logger, Connection $connection)
     {
         $this->logger = $logger;
+        $this->connection = $connection;
     }
 
     public function startQuery($sql, array $params = null, array $types = null)
     {
         $this->start = microtime(true);
 
-        $this->sql = preg_replace_callback("/\?/", function ($matches) use (&$params, &$types) {
-            $param = array_shift($params);
-            if (null === $param) {
-                return "NULL";
-            } else {
-                return "'" . $param . "'";
+        if ($params) {
+            list($sql, $params, $types) = SQLParserUtils::expandListParameters($sql, $params, $types);
+
+            $quotedParams = array();
+            foreach ($params as $typeIndex => $value) {
+                $quotedParams[] = $this->connection->quote($value, $types[$typeIndex]);
             }
-        }, $sql);
+
+            $this->sql = vsprintf(str_replace("?", "%s", $sql), $quotedParams);
+        } else {
+            $this->sql = $sql;
+        }
     }
 
     public function stopQuery()

--- a/src/Psr3Logger.php
+++ b/src/Psr3Logger.php
@@ -41,7 +41,10 @@ class Psr3Logger implements SQLLogger
 
             $quotedParams = array();
             foreach ($params as $typeIndex => $value) {
-                $quotedParams[] = $this->connection->quote($value, isset($types[$typeIndex]) ? $types[$typeIndex] : \PDO::PARAM_STR);
+                $quotedParams[] = $this->connection->quote(
+                    $value,
+                    isset($types[$typeIndex]) ? $types[$typeIndex] : \PDO::PARAM_STR
+                );
             }
 
             $this->sql = vsprintf(str_replace("?", "%s", $sql), $quotedParams);

--- a/src/Psr3Logger.php
+++ b/src/Psr3Logger.php
@@ -41,7 +41,7 @@ class Psr3Logger implements SQLLogger
 
             $quotedParams = array();
             foreach ($params as $typeIndex => $value) {
-                $quotedParams[] = $this->connection->quote($value, isset($types[$typeIndex]) ? $types[$typeIndex] : \PDO:PARAM_STR);
+                $quotedParams[] = $this->connection->quote($value, isset($types[$typeIndex]) ? $types[$typeIndex] : \PDO::PARAM_STR);
             }
 
             $this->sql = vsprintf(str_replace("?", "%s", $sql), $quotedParams);

--- a/src/Psr3Logger.php
+++ b/src/Psr3Logger.php
@@ -41,7 +41,7 @@ class Psr3Logger implements SQLLogger
 
             $quotedParams = array();
             foreach ($params as $typeIndex => $value) {
-                $quotedParams[] = $this->connection->quote($value, $types[$typeIndex]);
+                $quotedParams[] = $this->connection->quote($value, isset($types[$typeIndex]) ? $types[$typeIndex] : \PDO:PARAM_STR);
             }
 
             $this->sql = vsprintf(str_replace("?", "%s", $sql), $quotedParams);


### PR DESCRIPTION
This change resolves the issue #1 using the quote method from the database Driver. For this to work, I had to add another required parameter to the class constructor, so this is a breaking change.